### PR TITLE
Abehjati/fix-events-problems

### DIFF
--- a/IPyth.sol
+++ b/IPyth.sol
@@ -13,11 +13,11 @@ interface IPyth {
     /// @param chainId ID of the source chain that the batch price update containing this price.
     /// This value comes from Wormhole, and you can find the corresponding chains at https://docs.wormholenetwork.com/wormhole/contracts.
     /// @param sequenceNumber Sequence number of the batch price update containing this price.
-    /// @param lastPublsihTime Publish time of the previously stored price.
+    /// @param lastPublishTime Publish time of the previously stored price.
     /// @param publishTime Publish time of the given price update.
     /// @param price Current price of the given price update.
     /// @param conf Current confidence interval of the given price update.
-    event PriceFeedUpdate(bytes32 indexed id, bool indexed fresh, uint16 chainId, uint64 sequenceNumber, uint64 lastPublsihTime, uint64 publishTime, int64 price, uint64 conf);
+    event PriceFeedUpdate(bytes32 indexed id, bool indexed fresh, uint16 chainId, uint64 sequenceNumber, uint64 lastPublishTime, uint64 publishTime, int64 price, uint64 conf);
 
     /// @dev Emitted when a batch price update is processed successfully.
     /// @param chainId ID of the source chain that the batch price update comes from.
@@ -31,7 +31,6 @@ interface IPyth {
     /// @param batchCount Number of batches that this function processed.
     /// @param fee Amount of paid fee for updating the prices.
     event UpdatePriceFeeds(address indexed sender, uint batchCount, uint fee);
-
 
     /// @notice Returns the current price and confidence interval.
     /// @dev Reverts if the current price is not available.

--- a/IPyth.sol
+++ b/IPyth.sol
@@ -17,14 +17,14 @@ interface IPyth {
     /// @param publishTime Publish time of the given price update.
     /// @param price Current price of the given price update.
     /// @param conf Current confidence interval of the given price update.
-    event PriceFeedUpdate(bytes32 indexed id, bool indexed fresh, int8 chainId, uint64 sequenceNumber, uint64 lastPublsihTime, uint64 publishTime, int64 price, uint64 conf);
+    event PriceFeedUpdate(bytes32 indexed id, bool indexed fresh, uint16 chainId, uint64 sequenceNumber, uint64 lastPublsihTime, uint64 publishTime, int64 price, uint64 conf);
 
     /// @dev Emitted when a batch price update is processed successfully.
     /// @param chainId ID of the source chain that the batch price update comes from.
     /// @param sequenceNumber Sequence number of the batch price update.
     /// @param batchSize Number of prices within the batch price update.
     /// @param freshPricesInBatch Number of prices that were more recent and were stored.
-    event BatchPriceFeedUpdate(int8 chainId, uint64 sequenceNumber, uint batchSize, uint freshPricesInBatch);
+    event BatchPriceFeedUpdate(uint16 chainId, uint64 sequenceNumber, uint batchSize, uint freshPricesInBatch);
 
     /// @dev Emitted when a call to `updatePriceFeeds` is processed successfully.
     /// @param sender Sender of the call (`msg.sender`).

--- a/IPythAbi.json
+++ b/IPythAbi.json
@@ -4,9 +4,9 @@
     "inputs": [
       {
         "indexed": false,
-        "internalType": "int8",
+        "internalType": "uint16",
         "name": "chainId",
-        "type": "int8"
+        "type": "uint16"
       },
       {
         "indexed": false,
@@ -47,9 +47,9 @@
       },
       {
         "indexed": false,
-        "internalType": "int8",
+        "internalType": "uint16",
         "name": "chainId",
-        "type": "int8"
+        "type": "uint16"
       },
       {
         "indexed": false,

--- a/IPythAbi.json
+++ b/IPythAbi.json
@@ -60,7 +60,7 @@
       {
         "indexed": false,
         "internalType": "uint64",
-        "name": "lastPublsihTime",
+        "name": "lastPublishTime",
         "type": "uint64"
       },
       {

--- a/MockPyth.sol
+++ b/MockPyth.sol
@@ -30,7 +30,7 @@ contract MockPyth is AbstractPyth {
 
         // Chain ID is id of the source chain that the price update comes from. Since it is just a mock contract
         // We set it to 1.
-        int8 chainId = 1;
+        uint16 chainId = 1;
 
         for(uint i = 0; i < updateData.length; i++) {
             PythStructs.PriceFeed memory priceFeed = abi.decode(updateData[i], (PythStructs.PriceFeed));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "0.4.0",
+  "version": "0.4.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-sdk-solidity",
-      "version": "0.4.0",
+      "version": "0.4.0-beta.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "solc": "^0.8.15"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-sdk-solidity",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "solc": "^0.8.15"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "0.4.0",
+  "version": "0.4.0-beta.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",


### PR DESCRIPTION
chainId is uint16 (and not int8) and also `lastPublishTime` was spelled incorrectly.

It also releases 0.4.0-beta.0