### PR TITLE
Replace getPrevPrice with getLatestAvailablePrice

### DIFF
--- a/AbstractPyth.sol
+++ b/AbstractPyth.sol
@@ -28,12 +28,35 @@ abstract contract AbstractPyth is IPyth {
         return price;
     }
 
-    function getPrevPriceUnsafe(bytes32 id) external view override returns (PythStructs.Price memory price, uint64 publishTime) {
+    function getLatestAvailablePriceUnsafe(bytes32 id) public view override returns (PythStructs.Price memory price, uint64 publishTime) {
         PythStructs.PriceFeed memory priceFeed = queryPriceFeed(id);
+
+        price.expo = priceFeed.expo;
+        if (priceFeed.status == PythStructs.PriceStatus.TRADING) {
+            price.price = priceFeed.price;
+            price.conf = priceFeed.conf;
+            return (price, priceFeed.publishTime);
+        }
 
         price.price = priceFeed.prevPrice;
         price.conf = priceFeed.prevConf;
-        price.expo = priceFeed.expo;
         return (price, priceFeed.prevPublishTime);
+    }
+
+    function getLatestAvailablePriceWithinDuration(bytes32 id, uint64 duration) external view override returns (PythStructs.Price memory price) {
+        uint64 publishTime;
+        (price, publishTime) = getLatestAvailablePriceUnsafe(id);
+
+        require(diff(block.timestamp, publishTime) <= duration, "No available price within given duration");
+
+        return price;
+    }
+
+    function diff(uint x, uint y) private pure returns (uint) {
+        if (x > y) {
+            return x - y;
+        } else {
+            return y - x;
+        }
     }
 }

--- a/abis/AbstractPyth.json
+++ b/abis/AbstractPyth.json
@@ -190,7 +190,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "getPrevPriceUnsafe",
+    "name": "getLatestAvailablePriceUnsafe",
     "outputs": [
       {
         "components": [
@@ -218,6 +218,47 @@
         "internalType": "uint64",
         "name": "publishTime",
         "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "duration",
+        "type": "uint64"
+      }
+    ],
+    "name": "getLatestAvailablePriceWithinDuration",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "int64",
+            "name": "price",
+            "type": "int64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "conf",
+            "type": "uint64"
+          },
+          {
+            "internalType": "int32",
+            "name": "expo",
+            "type": "int32"
+          }
+        ],
+        "internalType": "struct PythStructs.Price",
+        "name": "price",
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",

--- a/abis/IPyth.json
+++ b/abis/IPyth.json
@@ -190,7 +190,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "getPrevPriceUnsafe",
+    "name": "getLatestAvailablePriceUnsafe",
     "outputs": [
       {
         "components": [
@@ -218,6 +218,47 @@
         "internalType": "uint64",
         "name": "publishTime",
         "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "duration",
+        "type": "uint64"
+      }
+    ],
+    "name": "getLatestAvailablePriceWithinDuration",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "int64",
+            "name": "price",
+            "type": "int64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "conf",
+            "type": "uint64"
+          },
+          {
+            "internalType": "int32",
+            "name": "expo",
+            "type": "int32"
+          }
+        ],
+        "internalType": "struct PythStructs.Price",
+        "name": "price",
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",

--- a/abis/MockPyth.json
+++ b/abis/MockPyth.json
@@ -270,7 +270,7 @@
         "type": "bytes32"
       }
     ],
-    "name": "getPrevPriceUnsafe",
+    "name": "getLatestAvailablePriceUnsafe",
     "outputs": [
       {
         "components": [
@@ -298,6 +298,47 @@
         "internalType": "uint64",
         "name": "publishTime",
         "type": "uint64"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "uint64",
+        "name": "duration",
+        "type": "uint64"
+      }
+    ],
+    "name": "getLatestAvailablePriceWithinDuration",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "int64",
+            "name": "price",
+            "type": "int64"
+          },
+          {
+            "internalType": "uint64",
+            "name": "conf",
+            "type": "uint64"
+          },
+          {
+            "internalType": "int32",
+            "name": "expo",
+            "type": "int32"
+          }
+        ],
+        "internalType": "struct PythStructs.Price",
+        "name": "price",
+        "type": "tuple"
       }
     ],
     "stateMutability": "view",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-sdk-solidity",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "solc": "^0.8.15"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",


### PR DESCRIPTION
It removes `getPrevPriceUnsafe` and adds two functions:
- `getLatestAvailablePriceUnsafe`
- `getLatestAvailablePriceWithinDuration` (which is a safe wrapper around the unsafe function)

Also releases v0.5.0 as this is a breaking change.