### PR TITLE
Abehjati/fix-mem-layout

### DIFF
--- a/AbstractPyth.sol
+++ b/AbstractPyth.sol
@@ -54,7 +54,7 @@ abstract contract AbstractPyth is IPyth {
         return price;
     }
 
-    function diff(uint x, uint y) private pure returns (uint) {
+    function diff(uint x, uint y) internal pure returns (uint) {
         if (x > y) {
             return x - y;
         } else {
@@ -63,9 +63,9 @@ abstract contract AbstractPyth is IPyth {
     }
 
     // Access modifier is overridden to public to be able to call it locally.
-    function updatePriceFeeds(bytes[] memory updateData) public virtual payable override;
+    function updatePriceFeeds(bytes[] calldata updateData) public virtual payable override;
 
-    function updatePriceFeedsIfNecessary(bytes[] memory updateData, bytes32[] memory priceIds, uint64[] memory publishTimes) external payable override {
+    function updatePriceFeedsIfNecessary(bytes[] calldata updateData, bytes32[] calldata priceIds, uint64[] calldata publishTimes) external payable override {
         require(priceIds.length == publishTimes.length, "priceIds and publishTimes arrays should have same length");
 
         bool updateNeeded = false;

--- a/IPyth.sol
+++ b/IPyth.sol
@@ -72,7 +72,7 @@ interface IPyth {
     /// The call will succeed even if the update is not the most recent.
     /// @dev Reverts if the transferred fee is not sufficient or the updateData is invalid.
     /// @param updateData Array of price update data.
-    function updatePriceFeeds(bytes[] memory updateData) external payable;
+    function updatePriceFeeds(bytes[] calldata updateData) external payable;
 
     /// @notice Wrapper around updatePriceFeeds that rejects fast if a price update is not necessary. A price update is
     /// necessary if the current on-chain publishTime is older than the given publishTime. It relies solely on the
@@ -90,7 +90,7 @@ interface IPyth {
     /// @param updateData Array of price update data.
     /// @param priceIds Array of price ids.
     /// @param publishTimes Array of publishTimes. `publishTimes[i]` corresponds to known `publishTime` of `priceIds[i]`
-    function updatePriceFeedsIfNecessary(bytes[] memory updateData, bytes32[] memory priceIds, uint64[] memory publishTimes) external payable;
+    function updatePriceFeedsIfNecessary(bytes[] calldata updateData, bytes32[] calldata priceIds, uint64[] calldata publishTimes) external payable;
 
     /// @notice Returns the required fee to update an array of price updates.
     /// @param updateDataSize Number of price updates.

--- a/MockPyth.sol
+++ b/MockPyth.sol
@@ -22,10 +22,14 @@ contract MockPyth is AbstractPyth {
     // Takes an array of encoded price feeds and stores them.
     // You can create this data either by calling createPriceFeedData or
     // by using web3.js or ethers abi utilities.
-    function updatePriceFeeds(bytes[] memory updateData) public override payable {
+    function updatePriceFeeds(bytes[] calldata updateData) public override payable {
         uint requiredFee = getUpdateFee(updateData.length);
         require(msg.value >= requiredFee, "Insufficient paid fee amount");
-        payable(msg.sender).transfer(msg.value - requiredFee);
+        
+        if (msg.value > requiredFee) {
+            (bool success, ) = payable(msg.sender).call{value: msg.value - requiredFee}("");
+            require(success, "Failed to transfer additional amount.");
+        }
 
         uint freshPrices = 0;
 

--- a/MockPyth.sol
+++ b/MockPyth.sol
@@ -28,7 +28,7 @@ contract MockPyth is AbstractPyth {
 
         if (msg.value > requiredFee) {
             (bool success, ) = payable(msg.sender).call{value: msg.value - requiredFee}("");
-            require(success, "Failed to transfer additional amount.");
+            require(success, "failed to transfer update fee");
         }
 
         uint freshPrices = 0;

--- a/MockPyth.sol
+++ b/MockPyth.sol
@@ -25,7 +25,7 @@ contract MockPyth is AbstractPyth {
     function updatePriceFeeds(bytes[] calldata updateData) public override payable {
         uint requiredFee = getUpdateFee(updateData.length);
         require(msg.value >= requiredFee, "Insufficient paid fee amount");
-        
+
         if (msg.value > requiredFee) {
             (bool success, ) = payable(msg.sender).call{value: msg.value - requiredFee}("");
             require(success, "Failed to transfer additional amount.");

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-sdk-solidity",
-      "version": "0.5.1",
+      "version": "0.5.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "solc": "^0.8.15"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Also some refactorings based on [solsecurity](https://github.com/transmissions11/solcurity)

The main reason for this change is that `updatePriceFeeds` in the actual contract (in pyth-crosschain) and a function that it calls use `calldata` and `updatePriceFeedsIfNecessary` is passing a `memory` argument. It causes a revert because `memory` cannot be converted to `calldata` (in a local function call). 

We could've have change the contract to use `memory` but using `calldata` here is more gas efficients and avoids a copy.
