### PR TITLE
Refactor the interface

### DIFF
--- a/AbstractPyth.sol
+++ b/AbstractPyth.sol
@@ -10,14 +10,19 @@ abstract contract AbstractPyth is IPyth {
     /// @param id The Pyth Price Feed ID of which to fetch the current price and confidence interval.
     function queryPriceFeed(bytes32 id) public view virtual returns (PythStructs.PriceFeed memory priceFeed);
 
+    /// @notice Returns true if a price feed with the given id exists.
+    /// @param id The Pyth Price Feed ID of which to check its existence.
+    function priceFeedExists(bytes32 id) public view virtual returns (bool exists);
+
+    /// @notice Returns the period (in seconds) that a price feed is considered valid since its publish time
+    function getValidTimePeriod() public view virtual returns (uint validTimePeriod);
+
     function getCurrentPrice(bytes32 id) external view override returns (PythStructs.Price memory price) {
-        PythStructs.PriceFeed memory priceFeed = queryPriceFeed(id);
+        uint64 publishTime;
+        (price, publishTime) = getLatestAvailablePriceUnsafe(id);
 
-        require(priceFeed.status == PythStructs.PriceStatus.TRADING, "current price unavailable");
+        require(diff(block.timestamp, publishTime) <= getValidTimePeriod(), "current price unavailable");
 
-        price.price = priceFeed.price;
-        price.conf = priceFeed.conf;
-        price.expo = priceFeed.expo;
         return price;
     }
 
@@ -70,7 +75,7 @@ abstract contract AbstractPyth is IPyth {
 
         bool updateNeeded = false;
         for(uint i = 0; i < priceIds.length; i++) {
-            if (queryPriceFeed(priceIds[i]).publishTime < publishTimes[i]) {
+            if (!priceFeedExists(priceIds[i]) || queryPriceFeed(priceIds[i]).publishTime < publishTimes[i]) {
                 updateNeeded = true;
             }
         }

--- a/MockPyth.sol
+++ b/MockPyth.sol
@@ -9,14 +9,24 @@ contract MockPyth is AbstractPyth {
     uint64 sequenceNumber;
 
     uint singleUpdateFeeInWei;
+    uint validTimePeriod;
 
-    constructor(uint _singleUpdateFeeInWei) {
+    constructor(uint _validTimePeriod, uint _singleUpdateFeeInWei) {
         singleUpdateFeeInWei = _singleUpdateFeeInWei;
+        validTimePeriod = _validTimePeriod;
     }
 
     function queryPriceFeed(bytes32 id) public override view returns (PythStructs.PriceFeed memory priceFeed) {
         require(priceFeeds[id].id != 0, "no price feed found for the given price id");
         return priceFeeds[id];
+    }
+
+    function priceFeedExists(bytes32 id) public override view returns (bool) {
+        return (priceFeeds[id].id != 0);
+    }
+
+    function getValidTimePeriod() public override view returns (uint) {
+        return validTimePeriod;
     }
 
     // Takes an array of encoded price feeds and stores them.

--- a/abis/AbstractPyth.json
+++ b/abis/AbstractPyth.json
@@ -284,6 +284,38 @@
     "type": "function"
   },
   {
+    "inputs": [],
+    "name": "getValidTimePeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "validTimePeriod",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "priceFeedExists",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
     "inputs": [
       {
         "internalType": "bytes32",

--- a/abis/AbstractPyth.json
+++ b/abis/AbstractPyth.json
@@ -308,7 +308,7 @@
     "outputs": [
       {
         "internalType": "bool",
-        "name": "",
+        "name": "exists",
         "type": "bool"
       }
     ],

--- a/abis/MockPyth.json
+++ b/abis/MockPyth.json
@@ -3,6 +3,11 @@
     "inputs": [
       {
         "internalType": "uint256",
+        "name": "_validTimePeriod",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
         "name": "_singleUpdateFeeInWei",
         "type": "uint256"
       }
@@ -358,6 +363,38 @@
         "internalType": "uint256",
         "name": "feeAmount",
         "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getValidTimePeriod",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "validTimePeriod",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      }
+    ],
+    "name": "priceFeedExists",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
       }
     ],
     "stateMutability": "view",

--- a/abis/MockPyth.json
+++ b/abis/MockPyth.json
@@ -374,7 +374,7 @@
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "validTimePeriod",
+        "name": "",
         "type": "uint256"
       }
     ],


### PR DESCRIPTION
This change has two purpose:
1) add priceFeedExists to handle the case when a price does not exist
in `updatePriceIfNecessary`.
try-catch doesn't work on local function call in solidity and we cannot
catch the revert there.
2) getValidTimePeriod(): There are some cases that the previous
getCurrentPrice implementation does not
cover and it is better to use the latestAvailablePrice.
However, we need to know the validity period and this is why it is added
here. It uses the unsafe function to have better revert message if it
occurs.
