### PR TITLE
Update getUpdateFee signature to take updateData

### DIFF
--- a/IPyth.sol
+++ b/IPyth.sol
@@ -113,7 +113,7 @@ interface IPyth {
     function updatePriceFeedsIfNecessary(bytes[] calldata updateData, bytes32[] calldata priceIds, uint64[] calldata publishTimes) external payable;
 
     /// @notice Returns the required fee to update an array of price updates.
-    /// @param updateDataSize Number of price updates.
+    /// @param updateData Array of price update data.
     /// @return feeAmount The required fee in Wei.
-    function getUpdateFee(uint updateDataSize) external view returns (uint feeAmount);
+    function getUpdateFee(bytes[] calldata updateData) external view returns (uint feeAmount);
 }

--- a/MockPyth.sol
+++ b/MockPyth.sol
@@ -33,7 +33,7 @@ contract MockPyth is AbstractPyth {
     // You can create this data either by calling createPriceFeedData or
     // by using web3.js or ethers abi utilities.
     function updatePriceFeeds(bytes[] calldata updateData) public override payable {
-        uint requiredFee = getUpdateFee(updateData.length);
+        uint requiredFee = getUpdateFee(updateData);
         require(msg.value >= requiredFee, "Insufficient paid fee amount");
 
         if (msg.value > requiredFee) {
@@ -74,8 +74,8 @@ contract MockPyth is AbstractPyth {
         emit UpdatePriceFeeds(msg.sender, 1, requiredFee);
     }
 
-    function getUpdateFee(uint updateDataSize) public override view returns (uint feeAmount) {
-        return singleUpdateFeeInWei * updateDataSize;
+    function getUpdateFee(bytes[] calldata updateData) public override view returns (uint feeAmount) {
+        return singleUpdateFeeInWei * updateData.length;
     }
 
     function createPriceFeedUpdateData(

--- a/abis/AbstractPyth.json
+++ b/abis/AbstractPyth.json
@@ -369,9 +369,9 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "updateDataSize",
-        "type": "uint256"
+        "internalType": "bytes[]",
+        "name": "updateData",
+        "type": "bytes[]"
       }
     ],
     "name": "getUpdateFee",

--- a/abis/IPyth.json
+++ b/abis/IPyth.json
@@ -369,9 +369,9 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "updateDataSize",
-        "type": "uint256"
+        "internalType": "bytes[]",
+        "name": "updateData",
+        "type": "bytes[]"
       }
     ],
     "name": "getUpdateFee",

--- a/abis/MockPyth.json
+++ b/abis/MockPyth.json
@@ -434,9 +434,9 @@
   {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "updateDataSize",
-        "type": "uint256"
+        "internalType": "bytes[]",
+        "name": "updateData",
+        "type": "bytes[]"
       }
     ],
     "name": "getUpdateFee",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-sdk-solidity",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "solc": "^0.8.15"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-sdk-solidity",
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "solc": "^0.8.15"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Change `getUpdateFee` to get the whole updateData. The underlying logic is the same but it might change in the future and this changes makes it future proof (so we can use some other information from the updataData)

Also, bumps the version to `2.0.0` as it is a breaking change.