### PR TITLE
Point reader to function variants in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ contract ExampleContract {
         pyth.updatePriceFeeds{value: fee}(priceUpdateData);
 
         bytes32 priceID = 0xf9c0172ba10dfa4d19088d94f5bf61d3b54d5bd7483a322a982e1373ee8ea31b;
+	// Read the current value of priceID, aborting the transaction if the price has not been updated recently.
+	// Every chain has a default recency threshold which can be retrieved by calling the getValidTimePeriod() function on the contract.
+	// Please see IPyth.sol for variants of this function that support configurable recency thresholds and other useful features.
         return pyth.getPrice(priceID);
     }
 }


### PR DESCRIPTION
SNX asked a question about how to use this getPrice function to support their use case, and it seemed to me like they didn't realize they should look at IPyth.sol to find more helper functions. add a pointer from the code example.