### PR TITLE
Update the SDK for downstream optimizations

### DIFF
--- a/AbstractPyth.sol
+++ b/AbstractPyth.sol
@@ -16,20 +16,20 @@ abstract contract AbstractPyth is IPyth {
 
     function getValidTimePeriod() public view virtual override returns (uint validTimePeriod);
 
-    function getPrice(bytes32 id) external view override returns (PythStructs.Price memory price) {
+    function getPrice(bytes32 id) external virtual view override returns (PythStructs.Price memory price) {
         return getPriceNoOlderThan(id, getValidTimePeriod());
     }
 
-    function getEmaPrice(bytes32 id) external view override returns (PythStructs.Price memory price) {
+    function getEmaPrice(bytes32 id) external virtual view override returns (PythStructs.Price memory price) {
         return getEmaPriceNoOlderThan(id, getValidTimePeriod());
     }
 
-    function getPriceUnsafe(bytes32 id) public view override returns (PythStructs.Price memory price) {
+    function getPriceUnsafe(bytes32 id) public virtual view override returns (PythStructs.Price memory price) {
         PythStructs.PriceFeed memory priceFeed = queryPriceFeed(id);
         return priceFeed.price;
     }
 
-    function getPriceNoOlderThan(bytes32 id, uint age) public view override returns (PythStructs.Price memory price) {
+    function getPriceNoOlderThan(bytes32 id, uint age) public virtual view override returns (PythStructs.Price memory price) {
         price = getPriceUnsafe(id);
 
         require(diff(block.timestamp, price.publishTime) <= age, "no price available which is recent enough");
@@ -37,12 +37,12 @@ abstract contract AbstractPyth is IPyth {
         return price;
     }
 
-    function getEmaPriceUnsafe(bytes32 id) public view override returns (PythStructs.Price memory price) {
+    function getEmaPriceUnsafe(bytes32 id) public virtual view override returns (PythStructs.Price memory price) {
         PythStructs.PriceFeed memory priceFeed = queryPriceFeed(id);
         return priceFeed.emaPrice;
     }
 
-    function getEmaPriceNoOlderThan(bytes32 id, uint age) public view override returns (PythStructs.Price memory price) {
+    function getEmaPriceNoOlderThan(bytes32 id, uint age) public virtual view override returns (PythStructs.Price memory price) {
         price = getEmaPriceUnsafe(id);
 
         require(diff(block.timestamp, price.publishTime) <= age, "no ema price available which is recent enough");
@@ -62,7 +62,7 @@ abstract contract AbstractPyth is IPyth {
     // Access modifier is overridden to public to be able to call it locally.
     function updatePriceFeeds(bytes[] calldata updateData) public virtual payable override;
 
-    function updatePriceFeedsIfNecessary(bytes[] calldata updateData, bytes32[] calldata priceIds, uint64[] calldata publishTimes) external payable override {
+    function updatePriceFeedsIfNecessary(bytes[] calldata updateData, bytes32[] calldata priceIds, uint64[] calldata publishTimes) external virtual payable override {
         require(priceIds.length == publishTimes.length, "priceIds and publishTimes arrays should have same length");
 
         bool updateNeeded = false;

--- a/IPyth.sol
+++ b/IPyth.sol
@@ -2,36 +2,12 @@
 pragma solidity ^0.8.0;
 
 import "./PythStructs.sol";
+import "./PythEvents.sol";
 
 /// @title Consume prices from the Pyth Network (https://pyth.network/).
 /// @dev Please refer to the guidance at https://docs.pyth.network/consumers/best-practices for how to consume prices safely.
 /// @author Pyth Data Association
-interface IPyth {
-    /// @dev Emitted when an update for price feed with `id` is processed successfully.
-    /// @param id The Pyth Price Feed ID.
-    /// @param fresh True if the price update is more recent and stored.
-    /// @param chainId ID of the source chain that the batch price update containing this price.
-    /// This value comes from Wormhole, and you can find the corresponding chains at https://docs.wormholenetwork.com/wormhole/contracts.
-    /// @param sequenceNumber Sequence number of the batch price update containing this price.
-    /// @param lastPublishTime Publish time of the previously stored price.
-    /// @param publishTime Publish time of the given price update.
-    /// @param price Price of the given price update.
-    /// @param conf Confidence interval of the given price update.
-    event PriceFeedUpdate(bytes32 indexed id, bool indexed fresh, uint16 chainId, uint64 sequenceNumber, uint lastPublishTime, uint publishTime, int64 price, uint64 conf);
-
-    /// @dev Emitted when a batch price update is processed successfully.
-    /// @param chainId ID of the source chain that the batch price update comes from.
-    /// @param sequenceNumber Sequence number of the batch price update.
-    /// @param batchSize Number of prices within the batch price update.
-    /// @param freshPricesInBatch Number of prices that were more recent and were stored.
-    event BatchPriceFeedUpdate(uint16 chainId, uint64 sequenceNumber, uint batchSize, uint freshPricesInBatch);
-
-    /// @dev Emitted when a call to `updatePriceFeeds` is processed successfully.
-    /// @param sender Sender of the call (`msg.sender`).
-    /// @param batchCount Number of batches that this function processed.
-    /// @param fee Amount of paid fee for updating the prices.
-    event UpdatePriceFeeds(address indexed sender, uint batchCount, uint fee);
-
+interface IPyth is PythEvents {
     /// @notice Returns the period (in seconds) that a price feed is considered valid since its publish time
     function getValidTimePeriod() external view returns (uint validTimePeriod);
 

--- a/IPyth.sol
+++ b/IPyth.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.0;
 
 import "./PythStructs.sol";
-import "./PythEvents.sol";
+import "./IPythEvents.sol";
 
 /// @title Consume prices from the Pyth Network (https://pyth.network/).
 /// @dev Please refer to the guidance at https://docs.pyth.network/consumers/best-practices for how to consume prices safely.
 /// @author Pyth Data Association
-interface IPyth is PythEvents {
+interface IPyth is IPythEvents {
     /// @notice Returns the period (in seconds) that a price feed is considered valid since its publish time
     function getValidTimePeriod() external view returns (uint validTimePeriod);
 

--- a/IPythEvents.sol
+++ b/IPythEvents.sol
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+/// @title IPythEvents contains the events that Pyth contract emits.
+/// @dev This interface can be used for listening to the updates for off-chain and testing purposes.
 interface IPythEvents {
-    /// @dev Emitted when an update for price feed with `id` is processed successfully.
+    /// @dev Emitted when the price feed with `id` has received a fresh update.
     /// @param id The Pyth Price Feed ID.
     /// @param publishTime Publish time of the given price update.
     /// @param price Price of the given price update.

--- a/IPythEvents.sol
+++ b/IPythEvents.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-interface PythEvents {
+interface IPythEvents {
     /// @dev Emitted when an update for price feed with `id` is processed successfully.
     /// @param id The Pyth Price Feed ID.
     /// @param publishTime Publish time of the given price update.

--- a/PythEvents.sol
+++ b/PythEvents.sol
@@ -4,26 +4,13 @@ pragma solidity ^0.8.0;
 interface PythEvents {
     /// @dev Emitted when an update for price feed with `id` is processed successfully.
     /// @param id The Pyth Price Feed ID.
-    /// @param fresh True if the price update is more recent and stored.
-    /// @param chainId ID of the source chain that the batch price update containing this price.
-    /// This value comes from Wormhole, and you can find the corresponding chains at https://docs.wormholenetwork.com/wormhole/contracts.
-    /// @param sequenceNumber Sequence number of the batch price update containing this price.
-    /// @param lastPublishTime Publish time of the previously stored price.
     /// @param publishTime Publish time of the given price update.
     /// @param price Price of the given price update.
     /// @param conf Confidence interval of the given price update.
-    event PriceFeedUpdate(bytes32 indexed id, bool indexed fresh, uint16 chainId, uint64 sequenceNumber, uint lastPublishTime, uint publishTime, int64 price, uint64 conf);
+    event PriceFeedUpdate(bytes32 indexed id, uint64 publishTime, int64 price, uint64 conf);
 
     /// @dev Emitted when a batch price update is processed successfully.
     /// @param chainId ID of the source chain that the batch price update comes from.
     /// @param sequenceNumber Sequence number of the batch price update.
-    /// @param batchSize Number of prices within the batch price update.
-    /// @param freshPricesInBatch Number of prices that were more recent and were stored.
-    event BatchPriceFeedUpdate(uint16 chainId, uint64 sequenceNumber, uint batchSize, uint freshPricesInBatch);
-
-    /// @dev Emitted when a call to `updatePriceFeeds` is processed successfully.
-    /// @param sender Sender of the call (`msg.sender`).
-    /// @param batchCount Number of batches that this function processed.
-    /// @param fee Amount of paid fee for updating the prices.
-    event UpdatePriceFeeds(address indexed sender, uint batchCount, uint fee);
+    event BatchPriceFeedUpdate(uint16 chainId, uint64 sequenceNumber);
 }

--- a/PythEvents.sol
+++ b/PythEvents.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+interface PythEvents {
+    /// @dev Emitted when an update for price feed with `id` is processed successfully.
+    /// @param id The Pyth Price Feed ID.
+    /// @param fresh True if the price update is more recent and stored.
+    /// @param chainId ID of the source chain that the batch price update containing this price.
+    /// This value comes from Wormhole, and you can find the corresponding chains at https://docs.wormholenetwork.com/wormhole/contracts.
+    /// @param sequenceNumber Sequence number of the batch price update containing this price.
+    /// @param lastPublishTime Publish time of the previously stored price.
+    /// @param publishTime Publish time of the given price update.
+    /// @param price Price of the given price update.
+    /// @param conf Confidence interval of the given price update.
+    event PriceFeedUpdate(bytes32 indexed id, bool indexed fresh, uint16 chainId, uint64 sequenceNumber, uint lastPublishTime, uint publishTime, int64 price, uint64 conf);
+
+    /// @dev Emitted when a batch price update is processed successfully.
+    /// @param chainId ID of the source chain that the batch price update comes from.
+    /// @param sequenceNumber Sequence number of the batch price update.
+    /// @param batchSize Number of prices within the batch price update.
+    /// @param freshPricesInBatch Number of prices that were more recent and were stored.
+    event BatchPriceFeedUpdate(uint16 chainId, uint64 sequenceNumber, uint batchSize, uint freshPricesInBatch);
+
+    /// @dev Emitted when a call to `updatePriceFeeds` is processed successfully.
+    /// @param sender Sender of the call (`msg.sender`).
+    /// @param batchCount Number of batches that this function processed.
+    /// @param fee Amount of paid fee for updating the prices.
+    event UpdatePriceFeeds(address indexed sender, uint batchCount, uint fee);
+}

--- a/abis/AbstractPyth.json
+++ b/abis/AbstractPyth.json
@@ -13,18 +13,6 @@
         "internalType": "uint64",
         "name": "sequenceNumber",
         "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "batchSize",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "freshPricesInBatch",
-        "type": "uint256"
       }
     ],
     "name": "BatchPriceFeedUpdate",
@@ -40,34 +28,10 @@
         "type": "bytes32"
       },
       {
-        "indexed": true,
-        "internalType": "bool",
-        "name": "fresh",
-        "type": "bool"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint16",
-        "name": "chainId",
-        "type": "uint16"
-      },
-      {
         "indexed": false,
         "internalType": "uint64",
-        "name": "sequenceNumber",
-        "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "lastPublishTime",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
         "name": "publishTime",
-        "type": "uint256"
+        "type": "uint64"
       },
       {
         "indexed": false,
@@ -83,31 +47,6 @@
       }
     ],
     "name": "PriceFeedUpdate",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "batchCount",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "fee",
-        "type": "uint256"
-      }
-    ],
-    "name": "UpdatePriceFeeds",
     "type": "event"
   },
   {

--- a/abis/IPyth.json
+++ b/abis/IPyth.json
@@ -13,18 +13,6 @@
         "internalType": "uint64",
         "name": "sequenceNumber",
         "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "batchSize",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "freshPricesInBatch",
-        "type": "uint256"
       }
     ],
     "name": "BatchPriceFeedUpdate",
@@ -40,34 +28,10 @@
         "type": "bytes32"
       },
       {
-        "indexed": true,
-        "internalType": "bool",
-        "name": "fresh",
-        "type": "bool"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint16",
-        "name": "chainId",
-        "type": "uint16"
-      },
-      {
         "indexed": false,
         "internalType": "uint64",
-        "name": "sequenceNumber",
-        "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "lastPublishTime",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
         "name": "publishTime",
-        "type": "uint256"
+        "type": "uint64"
       },
       {
         "indexed": false,
@@ -83,31 +47,6 @@
       }
     ],
     "name": "PriceFeedUpdate",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "batchCount",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "fee",
-        "type": "uint256"
-      }
-    ],
-    "name": "UpdatePriceFeeds",
     "type": "event"
   },
   {

--- a/abis/IPythEvents.json
+++ b/abis/IPythEvents.json
@@ -1,0 +1,52 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint16",
+        "name": "chainId",
+        "type": "uint16"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "sequenceNumber",
+        "type": "uint64"
+      }
+    ],
+    "name": "BatchPriceFeedUpdate",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "bytes32",
+        "name": "id",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "publishTime",
+        "type": "uint64"
+      },
+      {
+        "indexed": false,
+        "internalType": "int64",
+        "name": "price",
+        "type": "int64"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint64",
+        "name": "conf",
+        "type": "uint64"
+      }
+    ],
+    "name": "PriceFeedUpdate",
+    "type": "event"
+  }
+]

--- a/abis/MockPyth.json
+++ b/abis/MockPyth.json
@@ -29,18 +29,6 @@
         "internalType": "uint64",
         "name": "sequenceNumber",
         "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "batchSize",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "freshPricesInBatch",
-        "type": "uint256"
       }
     ],
     "name": "BatchPriceFeedUpdate",
@@ -56,34 +44,10 @@
         "type": "bytes32"
       },
       {
-        "indexed": true,
-        "internalType": "bool",
-        "name": "fresh",
-        "type": "bool"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint16",
-        "name": "chainId",
-        "type": "uint16"
-      },
-      {
         "indexed": false,
         "internalType": "uint64",
-        "name": "sequenceNumber",
-        "type": "uint64"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "lastPublishTime",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
         "name": "publishTime",
-        "type": "uint256"
+        "type": "uint64"
       },
       {
         "indexed": false,
@@ -99,31 +63,6 @@
       }
     ],
     "name": "PriceFeedUpdate",
-    "type": "event"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "sender",
-        "type": "address"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "batchCount",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "fee",
-        "type": "uint256"
-      }
-    ],
-    "name": "UpdatePriceFeeds",
     "type": "event"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-sdk-solidity",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "solc": "^0.8.15"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",

--- a/scripts/generateAbi.js
+++ b/scripts/generateAbi.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 const solc = require("solc");
 
 // Assuming each contract is in the file with the same name.
-var contracts = ["IPyth", "AbstractPyth", "MockPyth"];
+var contracts = ["IPyth", "IPythEvents", "AbstractPyth", "MockPyth"];
 
 var sources = {};
 var outputSelection = {};


### PR DESCRIPTION
This PR changes the SDK for optimization purposes that:
1. Removes unnecessary events and event fields. This will help to save ~8.5k gas upon a price update. This change is breaking for off-chain event listeners but non-breaking for on-chain consumers. So it has only a minor version change.
2. Makes all `AbstractPyth` methods virtual to allow the downstream contracts to override the methods for optimization.

It also moves the events to `IPythEvents` interface so they can be used in solidity tests. 