### PR TITLE
Add PythErrors.sol

### DIFF
--- a/MockPyth.sol
+++ b/MockPyth.sol
@@ -39,7 +39,7 @@ contract MockPyth is AbstractPyth {
         bytes[] calldata updateData
     ) public payable override {
         uint requiredFee = getUpdateFee(updateData);
-        if (msg.value < requiredFee) revert PythErrors.InsufficiantFee();
+        if (msg.value < requiredFee) revert PythErrors.InsufficientFee();
 
         // Chain ID is id of the source chain that the price update comes from. Since it is just a mock contract
         // We set it to 1.
@@ -85,7 +85,7 @@ contract MockPyth is AbstractPyth {
         uint64 maxPublishTime
     ) external payable override returns (PythStructs.PriceFeed[] memory feeds) {
         uint requiredFee = getUpdateFee(updateData);
-        if (msg.value < requiredFee) revert PythErrors.InsufficiantFee();
+        if (msg.value < requiredFee) revert PythErrors.InsufficientFee();
 
         feeds = new PythStructs.PriceFeed[](priceIds.length);
 

--- a/PythErrors.sol
+++ b/PythErrors.sol
@@ -10,7 +10,7 @@ library PythErrors {
     // Update data is invalid (e.g., deserialization error)
     error InvalidUpdateData();
     // Insufficient fee is paid to the method.
-    error InsufficiantFee();
+    error InsufficientFee();
     // There is no fresh update, whereas expected fresh updates.
     error NoFreshUpdate();
     // There is no price feed found within the given range or it does not exists.

--- a/PythErrors.sol
+++ b/PythErrors.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache 2
+
+pragma solidity ^0.8.0;
+
+library PythErrors {
+    // Function arguments are invalid (e.g., the arguments lengths mismatch)
+    error InvalidArgument();
+    // Update data is coming from an invalid data source.
+    error InvalidUpdateDataSource();
+    // Update data is invalid (e.g., deserialization error)
+    error InvalidUpdateData();
+    // Insufficient fee is paid to the method.
+    error InsufficiantFee();
+    // There is no fresh update, whereas expected fresh updates.
+    error NoFreshUpdate();
+    // There is no price feed found within the given range or it does not exists.
+    error PriceFeedNotFoundWithinRange();
+    // Price feed not found or it is not pushed on-chain yet.
+    error PriceFeedNotFound();
+    // Requested price is stale.
+    error StalePrice();
+    // Given message is not a valid Wormhole VAA.
+    error InvalidWormholeVaa();
+    // Governance message is invalid (e.g., deserialization error).
+    error InvalidGovernanceMessage();
+    // Governance message is not for this contract.
+    error InvalidGovernanceTarget();
+    // Governance message is coming from an invalid data source.
+    error InvalidGovernanceDataSource();
+    // Governance message is old.
+    error OldGovernanceMessage();
+}

--- a/abis/AbstractPyth.json
+++ b/abis/AbstractPyth.json
@@ -1,5 +1,20 @@
 [
   {
+    "inputs": [],
+    "name": "InvalidArgument",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoFreshUpdate",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "StalePrice",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {

--- a/abis/MockPyth.json
+++ b/abis/MockPyth.json
@@ -16,6 +16,36 @@
     "type": "constructor"
   },
   {
+    "inputs": [],
+    "name": "InsufficiantFee",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "InvalidArgument",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "NoFreshUpdate",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PriceFeedNotFound",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "PriceFeedNotFoundWithinRange",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "StalePrice",
+    "type": "error"
+  },
+  {
     "anonymous": false,
     "inputs": [
       {

--- a/abis/MockPyth.json
+++ b/abis/MockPyth.json
@@ -17,7 +17,7 @@
   },
   {
     "inputs": [],
-    "name": "InsufficiantFee",
+    "name": "InsufficientFee",
     "type": "error"
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pythnetwork/pyth-sdk-solidity",
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "prettier": "^2.7.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pythnetwork/pyth-sdk-solidity",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Read prices from the Pyth oracle",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add PythErrors and use them in the contract. This will reduce the contract size significantly.

Based on my changes it reduces current size of the contract (after merging [this](https://github.com/pyth-network/pyth-crosschain/pull/397)) from 23.69 to 20.94 KB (The limit is 24 KB)

This change might be considered breaking as people might have already try/catch it and checked the actual message (although unlikely). It's breaking for off-chain consumers such as price pusher. However, since we have not deployed the v2 contract, I consider it minor. Moving forward we should mark our not-deployed changes as alpha or beta. This one is going to be deployed soon and I don't add alpha/beta. 

Note: On this PR I also modified `parsePriceFeedUpdates` in the mock contract to be similar to the actual implementation.
